### PR TITLE
Change ASCII range numbers to be decimal and not octal

### DIFF
--- a/CPSL.tex
+++ b/CPSL.tex
@@ -109,7 +109,7 @@ A string constant represents a multi-character sequence and is enclosed in a pai
 A string constant may be empty.
 \subsection{Representing Characters in Character and String Constants}
 The newline character (ASCII 10) may not appear between the single or double quotes of a character or string constant.
-Any printable character (ASCII 40 to 176 inclusive) can be represented
+Any printable character (ASCII 32 to 126 inclusive) can be represented
 as itself with the exception of \textbackslash.
 Also such a constant can contain a \textbackslash followed by any printable character.  Such a \textbackslash - escaped sequence is interpreted as the character after the \textbackslash with the following exceptions:
 \begin{description}


### PR DESCRIPTION
Make it more consistent - in another place the values are listed
in Decimal, but here they were listed in Octal, which confused me,
personally.
