### PR TITLE
Syntax fixes

### DIFF
--- a/TestFiles/array_index.cpsl
+++ b/TestFiles/array_index.cpsl
@@ -14,7 +14,7 @@ begin
 	for i := 1 to 12 do
 		total := total + a[i];
 	end;
-	mean = total / 12;
+	mean := total / 12;
 	return mean;
 end;
 

--- a/TestFiles/checkers.cpsl
+++ b/TestFiles/checkers.cpsl
@@ -25,14 +25,14 @@ begin
     end;
   end;
 
-  turn = 0;
+  turn := 0;
 end;
 
 function pieces_remaining(label : char) : integer;
 var i, count : integer;
 begin
   remain := 0;
-  for i = 0 to 63 do
+  for i := 0 to 63 do
     if (game_board[i] = label) then
       remain := remain + 1;
     end;
@@ -52,7 +52,7 @@ begin
   end;
 end;
 
-function move_cell(cell, dir : integer);
+function move_cell(cell, dir : integer) : integer;
 var new, adj : integer;
 begin
   new := cell;
@@ -60,11 +60,11 @@ begin
   
   if dir = 0 then
     adj := -7;
-  else if dir = 1 then
+  elseif dir = 1 then
     adj := 9;
-  else if dir = 2 then
+  elseif dir = 2 then
     adj := 7;
-  else if dir = 3 then
+  elseif dir = 3 then
     adj := -9;
   end;
   new := new + adj;
@@ -72,7 +72,7 @@ begin
   $ This logic implements a cylinder shaped board.
   if game_board[new] = game_board[cell] then
     new := -1;
-  else if game_board[new] <> ' ' then
+  elseif game_board[new] <> ' ' then
     new := new + adj;
 
     if game_board[new] <> ' ' then
@@ -100,18 +100,18 @@ begin
     write("2 1\n");
 
     write("\nPick a direction: \n");
-    read(dir)
+    read(dir);
     write('\n');
 
     new := move_cell(cel, dir);
   end;
 
-  game_board[cell] = ' ';
-  game_board[new] = 'x';
+  game_board[cell] := ' ';
+  game_board[new] := 'x';
 
   $ Kind of a stupid way to do this, with the division.
   if (new - cell) > 9 then
-    game_board[cell + ((new - cell) / 2)] = ' ';
+    game_board[cell + ((new - cell) / 2)] := ' ';
   end;
 end;
 
@@ -132,18 +132,18 @@ begin
     write("2 1\n");
 
     write("\nPick a direction: \n");
-    read(dir)
+    read(dir);
     write('\n');
 
     new := move_cell(cel, dir);
   end;
 
-  game_board[cell] = ' ';
-  game_board[new] = 'o';
+  game_board[cell] := ' ';
+  game_board[new] := 'o';
 
   $ Kind of a stupid way to do this, with the division.
   if (new - cell) > 9 then
-    game_board[cell + ((new - cell) / 2)] = ' ';
+    game_board[cell + ((new - cell) / 2)] := ' ';
   end;
 end;
 
@@ -152,11 +152,11 @@ var i, cell, dir : integer;
 begin
   for i := 0 to 63 do
     if game_board[i] = 'o' then
-      cell = i;
+      cell := i;
     end;
   end;
 
-  dir = 0;
+  dir := 0;
 
   $ Note, AI player does not actually move, is not used.
 end;
@@ -173,7 +173,7 @@ begin
       player_o_move();
     end;
 
-    turn = (turn + 1) % 2;
+    turn := (turn + 1) % 2;
   end;
 
   if pieces_remaining('x') > 0 then

--- a/TestFiles/for_down.cpsl
+++ b/TestFiles/for_down.cpsl
@@ -7,4 +7,4 @@ BEGIN
     write(i, " \n");
   end;
 
-END
+END.

--- a/TestFiles/for_to.cpsl
+++ b/TestFiles/for_to.cpsl
@@ -7,4 +7,4 @@ BEGIN
     write(i, " \n");
   end;
 
-END
+END.

--- a/TestFiles/game_form.cpsl
+++ b/TestFiles/game_form.cpsl
@@ -22,9 +22,9 @@ begin
   Write("Enter Away team score \n");
   read(hscore.score2);
   if hscore.score1 > hscore.score2 then
-	bool1 = true;
+	bool1 := true;
   else
-	bool1 = false;
+	bool1 := false;
   end;
 end;
 
@@ -50,6 +50,7 @@ begin
       then write("WIN \n");
     else
        write("LOSS OR DRAW \n");
+    end;
   end;
 end;
 
@@ -64,8 +65,3 @@ begin
   readtable();
   printtable();
 end.
-
-  
-  
-     
-

--- a/TestFiles/hanoi.cpsl
+++ b/TestFiles/hanoi.cpsl
@@ -1,6 +1,6 @@
 var disks : integer;
 
-procedure moveTower(var disk: integer; source,dest,spare: character)
+procedure moveTower(var disk: integer; source,dest,spare: character);
 begin
 	if(disk=1) then
 		write("Move ",disk," from ",source," to ",dest,'\n');

--- a/syntax_check.sh
+++ b/syntax_check.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This script uses the CS6300 compiler (https://github.com/ksundberg/CS6300)
+# to verify files are free of syntax errors.
+DARK_GREY='\033[1;30m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if [ -z $1 ]; then
+    echo "usage: syntax_check.sh pattern_for_test_files /path/to/compiler"
+    exit 1;
+fi
+
+filelist=($@)
+echo -e "${DARK_GREY} ${#filelist[@]} file(s) being parsed${NC}"
+mkdir parser_logs
+mkdir asm_output
+for ((i=0; i < ${#filelist[@]}-1; i++)); do
+    filepatharr=(${filelist[$i]//\// })
+    filename=${filepatharr[${#filepatharr[@]}-1]}
+    echo -e "${DARK_GREY}Parsing ${filelist[$i]}${NC}"
+    result="$(${@: -1} -i ${filelist[$i]} -o asm_output/${filename}.asm)"
+    echo "${result}" > parser_logs/${filename}_output.txt
+    if [[ $result == *"syntax error"* ]]; then
+      echo -e "${RED}Syntax errors in ${filename}${NC}"
+    elif [[ $result != "" ]]; then
+      echo -e "${YELLOW}Other compile time errors in ${filename}${NC}"
+    else
+      echo -e "${GREEN}Successfully compiled ${filename}${NC}"
+    fi
+done

--- a/tester/TestFiles/checkers.cpsl
+++ b/tester/TestFiles/checkers.cpsl
@@ -25,14 +25,14 @@ begin
     end;
   end;
 
-  turn = 0;
+  turn := 0;
 end;
 
 function pieces_remaining(label : char) : integer;
 var i, count : integer;
 begin
   remain := 0;
-  for i = 0 to 63 do
+  for i := 0 to 63 do
     if (game_board[i] = label) then
       remain := remain + 1;
     end;
@@ -52,7 +52,7 @@ begin
   end;
 end;
 
-function move_cell(cell, dir : integer);
+function move_cell(cell, dir : integer) : integer;
 var new, adj : integer;
 begin
   new := cell;
@@ -60,11 +60,11 @@ begin
   
   if dir = 0 then
     adj := -7;
-  else if dir = 1 then
+  elseif dir = 1 then
     adj := 9;
-  else if dir = 2 then
+  elseif dir = 2 then
     adj := 7;
-  else if dir = 3 then
+  elseif dir = 3 then
     adj := -9;
   end;
   new := new + adj;
@@ -72,7 +72,7 @@ begin
   $ This logic implements a cylinder shaped board.
   if game_board[new] = game_board[cell] then
     new := -1;
-  else if game_board[new] <> ' ' then
+  elseif game_board[new] <> ' ' then
     new := new + adj;
 
     if game_board[new] <> ' ' then
@@ -100,18 +100,18 @@ begin
     write("2 1\n");
 
     write("\nPick a direction: \n");
-    read(dir)
+    read(dir);
     write('\n');
 
     new := move_cell(cel, dir);
   end;
 
-  game_board[cell] = ' ';
-  game_board[new] = 'x';
+  game_board[cell] := ' ';
+  game_board[new] := 'x';
 
   $ Kind of a stupid way to do this, with the division.
   if (new - cell) > 9 then
-    game_board[cell + ((new - cell) / 2)] = ' ';
+    game_board[cell + ((new - cell) / 2)] := ' ';
   end;
 end;
 
@@ -132,18 +132,18 @@ begin
     write("2 1\n");
 
     write("\nPick a direction: \n");
-    read(dir)
+    read(dir);
     write('\n');
 
     new := move_cell(cel, dir);
   end;
 
-  game_board[cell] = ' ';
-  game_board[new] = 'o';
+  game_board[cell] := ' ';
+  game_board[new] := 'o';
 
   $ Kind of a stupid way to do this, with the division.
   if (new - cell) > 9 then
-    game_board[cell + ((new - cell) / 2)] = ' ';
+    game_board[cell + ((new - cell) / 2)] := ' ';
   end;
 end;
 
@@ -152,11 +152,11 @@ var i, cell, dir : integer;
 begin
   for i := 0 to 63 do
     if game_board[i] = 'o' then
-      cell = i;
+      cell := i;
     end;
   end;
 
-  dir = 0;
+  dir := 0;
 
   $ Note, AI player does not actually move, is not used.
 end;
@@ -173,7 +173,7 @@ begin
       player_o_move();
     end;
 
-    turn = (turn + 1) % 2;
+    turn := (turn + 1) % 2;
   end;
 
   if pieces_remaining('x') > 0 then


### PR DESCRIPTION
# Syntax Fixes for CPSL Test Files

The added test script allows for compiling multiple CPSL files while checking for syntax and other errors. Primary purpose of the script is to test files for syntax errors.

## Missing Colon in Assignment Operator
* TestFiles/array_index.cpsl
* TestFiles/game_form.cpsl
* TestFiles/checkers.cpsl

## Missing Period at End of Program
* TestFiles/for_down.cpsl
* TestFiles/for_to.cpsl

## checkers.cpsl
* Multiple missing colons
* Missing type on function declaration
* All elseif statements had a space.
* Still doesn't compile due to semantic issues. Other syntax errors may exist.

## hanoi.cpsl
* Missing a semi-colon at end of procedure declaration
* Doesn't compile due to other issues

## game_form.cpsl
* Missing colons in assign op
* Missing end key for a conditional block
* Doesn't compile due to other issues
